### PR TITLE
Fix node_modules folder on compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       target: development
     volumes:
       - .:/usr/src/app
+      - /usr/src/app/node_modules
     # Override the Dockerfile command
     command: npm run start:dev
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,8 @@ services:
       target: development
     volumes:
       - .:/usr/src/app
-      - /usr/src/app/node_modules
     # Override the Dockerfile command
-    command: npm run start:dev
+    command: bash -c "npm ci && npm run start:dev"
     ports:
       - 3000:3000
     networks:


### PR DESCRIPTION
Fix para quando não se tem o node_modules na máquina host, assim podemos utilizar o `docker compose up` direto sem necessidade de um passo extra com o `docker compose run`. 